### PR TITLE
Streaming branch updated

### DIFF
--- a/examples/ba_cpp_example.cpp
+++ b/examples/ba_cpp_example.cpp
@@ -57,8 +57,8 @@ int main(int argc, char *argv[]) {
   t.restart();
   unsigned int edges = 0;
   for (unsigned int i = 0; i < n; i++) {
-    std::vector<unsigned int> neighbors =
-        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD);
+    std::vector<unsigned int> neighbors;
+        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD, neighbors);
     overall_time += t.elapsed();
     edges += neighbors.size();
     /*out << i + 1 << ": ";

--- a/examples/rdg2d_cpp_example.cpp
+++ b/examples/rdg2d_cpp_example.cpp
@@ -57,8 +57,8 @@ int main(int argc, char *argv[]) {
   t.restart();
   unsigned int edges = 0;
   for (unsigned int i = 0; i < n; i++) {
-    std::vector<unsigned int> neighbors =
-        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD);
+    std::vector<unsigned int> neighbors;
+        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD, neighbors);
     overall_time += t.elapsed();
     edges += neighbors.size();
     /*out << i + 1 << ": ";

--- a/examples/rdg3d_cpp_example.cpp
+++ b/examples/rdg3d_cpp_example.cpp
@@ -57,8 +57,8 @@ int main(int argc, char *argv[]) {
   t.restart();
   unsigned int edges = 0;
   for (unsigned int i = 0; i < n; i++) {
-    std::vector<unsigned int> neighbors =
-        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD);
+    std::vector<unsigned int> neighbors;
+        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD, neighbors);
     overall_time += t.elapsed();
     edges += neighbors.size();
     /*out << i + 1 << ": ";

--- a/examples/rgg2d_cpp_example.cpp
+++ b/examples/rgg2d_cpp_example.cpp
@@ -57,15 +57,15 @@ int main(int argc, char *argv[]) {
   t.restart();
   unsigned int edges = 0;
   for (unsigned int i = 0; i < n; i++) {
-    std::vector<unsigned int> neighbors =
-        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD);
+    std::vector<unsigned int> neighbors; 
+        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD, neighbors);
     overall_time += t.elapsed();
     edges += neighbors.size();
-    /*out << i + 1 << ": ";
+	std::cout << i << ": ";
     for (unsigned int j = 0; j < neighbors.size(); j++) {
-      out << neighbors[j] << " ";
+		std::cout << neighbors[j] << " ";
     }
-    out << std::endl;*/
+	std::cout << std::endl;
     t.restart();
     //  std::cout << neighbors.first + 1 << ": ";
     //  for (int j = 0; j < neighbors.second.size(); j++) {

--- a/examples/rgg2d_cpp_example.cpp
+++ b/examples/rgg2d_cpp_example.cpp
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
         streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD, neighbors);
     overall_time += t.elapsed();
     edges += neighbors.size();
-	std::cout << i << ": ";
+	std::cout << i+1 << ": ";
     for (unsigned int j = 0; j < neighbors.size(); j++) {
 		std::cout << neighbors[j] << " ";
     }

--- a/examples/rgg3d_cpp_example.cpp
+++ b/examples/rgg3d_cpp_example.cpp
@@ -57,8 +57,8 @@ int main(int argc, char *argv[]) {
   t.restart();
   unsigned int edges = 0;
   for (unsigned int i = 0; i < n; i++) {
-    std::vector<unsigned int> neighbors =
-        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD);
+    std::vector<unsigned int> neighbors;
+        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD, neighbors);
     overall_time += t.elapsed();
     edges += neighbors.size();
     /*out << i + 1 << ": ";

--- a/examples/rhg_cpp_example.cpp
+++ b/examples/rhg_cpp_example.cpp
@@ -58,10 +58,15 @@ int main(int argc, char *argv[]) {
   t.restart();
   unsigned int edges = 0;
   for (unsigned int i = 0; i < n; i++) {
-    std::vector<unsigned int> neighbors =
-        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD);
+    std::vector<unsigned int> neighbors;
+        streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD, neighbors);
     overall_time += t.elapsed();
     edges += neighbors.size();
+	std::cout << i << ": ";
+	for(unsigned int j = 0; j < neighbors.size(); j++) {
+		std::cout << neighbors[j] << " "; 
+	}
+	std::cout << std::endl; 
     /*out << i + 1 << ": ";
     for (unsigned int j = 0; j < neighbors.size(); j++) {
       out << neighbors[j] << " ";

--- a/examples/rhg_cpp_example.cpp
+++ b/examples/rhg_cpp_example.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[]) {
         streamGenerator.streamVertex(i + 1, MPI_COMM_WORLD, neighbors);
     overall_time += t.elapsed();
     edges += neighbors.size();
-	std::cout << i << ": ";
+	std::cout << i+1 << ": ";
 	for(unsigned int j = 0; j < neighbors.size(); j++) {
 		std::cout << neighbors[j] << " "; 
 	}

--- a/kagen/kagen.cpp
+++ b/kagen/kagen.cpp
@@ -827,9 +827,9 @@ StreamingGenerator::generateVertex(MPI_Comm comm) {
   }
 }
 
-std::vector<unsigned int> StreamingGenerator::streamVertex(unsigned int vertex,
-                                                           MPI_Comm comm) {
-  std::vector<unsigned int> neighbors;
+// make sure empty vector is given.
+void StreamingGenerator::streamVertex(unsigned int vertex, MPI_Comm comm, std::vector<unsigned int>& neighbors) {
+  //std::vector<unsigned int> neighbors;
   if (vertex == 1) { // this is we are starting the stream
     // for (unsigned int k = 0; k < vertex_distribution.size(); k++) {
     //   std::cout << vertex_distribution[k] << std::endl;
@@ -888,7 +888,11 @@ std::vector<unsigned int> StreamingGenerator::streamVertex(unsigned int vertex,
   auto last = std::unique(neighbors.begin(), neighbors.end());
   neighbors.erase(last, neighbors.end());
 
-  return neighbors;
+	for(unsigned int u = 0; u < neighbors.size(); u++) {
+		neighbors[u]--;
+	}
+
+  //return neighbors;
 }
 
 bool StreamingGenerator::isChunkEmpty(unsigned int vertex) {

--- a/kagen/kagen.cpp
+++ b/kagen/kagen.cpp
@@ -888,9 +888,9 @@ void StreamingGenerator::streamVertex(unsigned int vertex, MPI_Comm comm, std::v
   auto last = std::unique(neighbors.begin(), neighbors.end());
   neighbors.erase(last, neighbors.end());
 
-	for(unsigned int u = 0; u < neighbors.size(); u++) {
-		neighbors[u]--;
-	}
+//	for(unsigned int u = 0; u < neighbors.size(); u++) {
+//		neighbors[u]--;
+//	}
 
   //return neighbors;
 }

--- a/kagen/kagen.h
+++ b/kagen/kagen.h
@@ -508,7 +508,7 @@ namespace kagen {
 class StreamingGenerator {
 public:
   StreamingGenerator(MPI_Comm comm, int chunks);
-  std::vector<unsigned int> streamVertex(unsigned int vertex, MPI_Comm comm);
+  void streamVertex(unsigned int vertex, MPI_Comm comm, std::vector<unsigned int>& neighbors);
   std::pair<unsigned int, std::vector<unsigned int>>
   getNextVertex(MPI_Comm comm, unsigned int vertex);
   std::pair<unsigned int, std::vector<unsigned int>>


### PR DESCRIPTION
Checked the RGG and RHG streaming generator again

The neighbourhoods are now filled by giving the streamVertex function an empty vector which then gets filled. This avoids copying. I also adjusted the examples. Labels of the vertices still start from 1 